### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CoD4x_Server [![Build Status](https://travis-ci.org/D4edalus/CoD4x1.8_Server_Pub.svg?branch=master)](https://travis-ci.org/D4edalus/CoD4x1.8_Server_Pub)
+# CoD4X Server [![Build Status](https://travis-ci.org/D4edalus/CoD4x1.8_Server_Pub.svg?branch=master)](https://travis-ci.org/D4edalus/CoD4x1.8_Server_Pub)
 Cod4X is a modification of the Call of Duty 4 - Modern Warfare server. It fixes several bugs in the original binaries and allows developers to extend server functionality with additional variables and plugins. When using the CoD4x server, the clients invoke  installation of the proprietary Cod4X client to players joining the server using the Cod4X servers, which fixes several known base game bugs in the client, and in combination with the server allows for extra features.
 
 ## The most prominent features are:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# CoD4x_Server_1.8_Public [![Build Status](https://travis-ci.org/D4edalus/CoD4x1.8_Server_Pub.svg?branch=master)](https://travis-ci.org/D4edalus/CoD4x1.8_Server_Pub)
-Cod4X is a modification of the Call of Duty 4 - Modern Warfare server. It fixes several bugs in the original binaries and allows developers to extend server functionality with additional variables and plugins. When using the CoD4x server, the clients invoke  installation of the proprietary Cod4X client to players joining the server using the Cod4X servers (https://cod4x.me), which fixes several known base game bugs in the client, and in combination with the server allows for extra features.
+# CoD4x_Server [![Build Status](https://travis-ci.org/D4edalus/CoD4x1.8_Server_Pub.svg?branch=master)](https://travis-ci.org/D4edalus/CoD4x1.8_Server_Pub)
+Cod4X is a modification of the Call of Duty 4 - Modern Warfare server. It fixes several bugs in the original binaries and allows developers to extend server functionality with additional variables and plugins. When using the CoD4x server, the clients invoke  installation of the proprietary Cod4X client to players joining the server using the Cod4X servers, which fixes several known base game bugs in the client, and in combination with the server allows for extra features.
 
 ## The most prominent features are:
 * Administration commands
@@ -8,23 +8,24 @@ Cod4X is a modification of the Call of Duty 4 - Modern Warfare server. It fixes 
 * Pbss like screenshot feature
 * Automated client update, no manual installation needed
 * Backwards compatibility to 1.7 and 1.7a servers
-* Masterserver, when the official one is down again q.q http://cod4master.cod4x.me/
-* [More](http://todo)
+* A new [masterserver](http://cod4master.cod4x.me/), for when the official masterserver is down
 
 The Cod4X server can run on Windows and Linux. 
 The Cod4X client update is only available for windows.
 
 ## Setting up a Call of Duty 4 server with Cod4x 1.8
-Get the binary release package from http://cod4x.me
+[Pre-compiled binaries Linux](https://cod4x.me/downloads/cod4x_server-linux.zip)
 
-Directlink: http://cod4x.me/index.php?attachments/serverfiles_15-6-zip.19/
+[Pre-compiled binaries Windows](https://cod4x.me/downloads/cod4x_server-windows.zip)
 
 You also require the base game to run a server. Copy every .iwd file in `cod4directory/main/` to `serverdirectory/main/`.
 Also copy everything inside `cod4directory/zone` to `serverdirectory/zone`.
 
 Now you can run the server with `./cod4x18_dedrun +map mp_killhouse`. If you are running a local server on Windows use `cod4x18_dedrun.exe +map mp_killhouse +set dedicated 2 +set net_ip 127.0.0.1`. Join the server with your client via the console (`^`) by typing `/connect 127.0.0.1` (if hosted locally), and see if you can join the server.
 
-<small>Hint: you probably want to run the server on a separate user. Please don't run the server (any server) as root. That would be a major security threat.</small>
+Hint: you probably want to run the server on a separate user. Please don't run the server (any server) as root. That would be a major security threat.
+
+A more detailed server tutorial is available on [our wiki](https://github.com/D4edalus/CoD4x_Server/wiki/Server-setup).
 
 ## Compiling
 To compile Cod4X from source you require the following tools:
@@ -32,16 +33,27 @@ To compile Cod4X from source you require the following tools:
 - paxctl (not needed for Debian or Windows)
 - gcc on Linux or mingw32 on Windows
 
-Debian/Ubuntu 32-bit:`apt install nasm paxctl build-essential`
+Debian/Ubuntu 32-bit:
+```
+sudo apt install nasm paxctl build-essential
+```
 
 Debian/Ubuntu 64-bit:
-```dpkg --add-architecture i386
-apt-get update
-apt-get install nasm:i386 build-essential gcc-multilib g++-multilib```
+```
+sudo dpkg --add-architecture i386
+sudo apt-get update
+sudo apt-get install nasm:i386 build-essential gcc-multilib g++-multilib
+```
 
-openSUSE 32-bit: `sudo zypper install nasm gcc-32bit gcc-c++-32bit`
+openSUSE 32-bit: 
+```
+sudo zypper install nasm gcc-32bit gcc-c++-32bit
+```
  
-Arch Linux 32-bit: `yaourt -S nasm paxctl build-essential`
+Arch Linux 32-bit: 
+```
+yaourt -S nasm paxctl build-essential
+```
 
 Compile the server with `./build_updateable_elf.sh`.
 If compilation was successful the binary will be placed in the `bin/` folder.
@@ -49,16 +61,29 @@ If compilation was successful the binary will be placed in the `bin/` folder.
 ##Contributing
 Cod4X is licensed under the AGPL3 license. We welcome anybody to fork this project and submit a pull request.
 
-Plugins can be written in C/C++. We also provide language bindings for D. The `/plugins` directory contains some example plugins. You can contribute to the project by developing plugins and create a pull request for them and/or uploading and promoting them on the [forums](https://cod4x.me/).
+Plugins can be written in C/C++ and we also provide language bindings for D. The `/plugins` directory contains some example plugins. You can contribute to the project by developing plugins and create a pull request for them and/or uploading and promoting them on the [forums](https://cod4x.me/forum/forum-17.html).
 
 If you want to contribute to the core project check the issue tracker for todos. We will try our best to keep the issue tracker filled with new bits.
-If you would like to work on a completely new feature, we would appreciate if you contact us first on the forums or on github to discuss the idea.
+If you would like to work on a completely new feature, we would appreciate if you contact us first on the forums or on Github to discuss the idea.
 
 If you're not a programmer but still want to help, you can help by testing and reporting bugs, but also by writing documentation. Please submit your bug reports to the Github issue tracker.
 
 ## Usage conditions for server hosters
-If you plan on hosting your own servers, please have a look at the usage conditions. https://cod4x.me/index.php?threads/cod4x18-server-usage-conditions.61/
-Those conditions have been established to keep user created content open to everyone, and also to value the work on CoD4X.
+Aside from agreeing to the license, by making any use of CoD4X18 server you agree to the following:
+
+1. You make content which is connected to your CoD4X18 Server available to the developers on request. For example if you run a mod, you have to make everything available that is required to run another server just like your own. Think of a complete mod.ff, .iwds, plugins, database handlers, etc.
+
+2. The developers reserve the right to reuse your content as long as it is not used commercially. You have a right for your name/clan/website getting mentioned if this is going to happen.
+They can also use it on their own servers.
+
+3. Maps you have installed on a server have to be either available on the internet already, or be made available to the community at the [Cod4X forums](https://cod4x.me/forum/forum-24.html), with all required assets, like scripts, within 20 weeks of installation. You have to annouce your map on the [forums](https://cod4x.me/forum/) on the same day you have installed it to gain the 20 weeks grace period. Not announced maps will have to be made available within 1 week.
+
+4. Plugins have to be made available as sourcecode so the user can interact with it
+
+Server's IPs violating these conditions can get permanently disabled.
+Servers hosted by Luxhosting are not affected by these conditions.
+
+These conditions have been established to keep user created content open to everyone, and also to value the work on CoD4X.
 
 ## Everything else
-Please check out the [forums](https://cod4x.me).
+Please check out the [forums](https://cod4x.me) and [our wiki](https://github.com/D4edalus/CoD4x_Server/wiki).


### PR DESCRIPTION
- Removed visible url's and changed them for proper links. Visible url's should be avoided where possible
- Added direct binary links for both Linux and Windows
- Properly formatted the compilation section
- Linked the Github wiki for a more detailed server tutorial
- Added usage conditions from the old forums, and fixed it's typos
- Since the project is AGPL3 licensed, users are required to provide (modified) server sourecode when requested by both players and developers, thus removing the need of mentioning this in the server conditions. Altered the text to be in line with this

Even though I added the usage conditions to the README.md, I still don't think the usage conditions are a good thing. Any modified server code should be given if requested anyway, the same with any plugins released under AGPL3.
Any server running a custom map will upload the map to the client anyway, so there is not really a need for server providers to provide the map.
Currently the usage conditions only scare server admins away, which prevents adoption of Cod4X. Also, I don't think it's really possible to enforce these conditions anyway.

Also think of moving every plugin to it's own repo. This'll make developing and updating Cod4X provided plugins easier, and it gives a better history of changes to both the core server and the plugins if they're seperated from each other. If you do, make sure you all license them under AGPL3, so you require server admins to provide the source of the plugins if they modified it.